### PR TITLE
fixed the bugs in data feed

### DIFF
--- a/hummingbot/data_feed/candles_feed/bybit_perpetual_candles/bybit_perpetual_candles.py
+++ b/hummingbot/data_feed/candles_feed/bybit_perpetual_candles/bybit_perpetual_candles.py
@@ -82,7 +82,7 @@ class BybitPerpetualCandles(CandlesBase):
                                                        throttler_limit_id=CONSTANTS.CANDLES_ENDPOINT,
                                                        params=params)
 
-        ts = candles["result"]["list"]
+        ts = candles["result"]["list"][::-1]
         return np.array(ts).astype(float)
 
     async def fill_historical_candles(self):
@@ -141,7 +141,7 @@ class BybitPerpetualCandles(CandlesBase):
             data: Dict[str, Any] = ws_response.data
             # data will be None when the websocket is disconnected
             if data is not None and data.get("topic", "").startswith("kline"):
-                timestamp = int(data["data"][0]["timestamp"])
+                timestamp = int(data["data"][0]["start"])
                 open = float(data["data"][0]["open"])
                 low = float(data["data"][0]["low"])
                 high = float(data["data"][0]["high"])

--- a/hummingbot/data_feed/candles_feed/bybit_perpetual_candles/bybit_perpetual_candles.py
+++ b/hummingbot/data_feed/candles_feed/bybit_perpetual_candles/bybit_perpetual_candles.py
@@ -108,9 +108,9 @@ class BybitPerpetualCandles(CandlesBase):
                 raise
             except Exception:
                 self.logger().exception(
-                    "Unexpected error occurred when getting historical klines. Retrying in 1 seconds...",
+                    "Unexpected error occurred when getting historical klines. Retrying in 5 seconds...",
                 )
-                await self._sleep(1.0)
+                await self._sleep(5.0)
 
     async def _subscribe_channels(self, ws: WSAssistant):
         """


### PR DESCRIPTION
This PR fixed the followings:
1. fetch_candles() will produce array in descending timestamp -> reverse the order
2. fetch_candles() retry interval changed to 5 seconds (actually getting all data faster than overwhelming the api endpoint)
3. _process_websocket_messages() should use data[0]['start'] as timestamp

**Original:** 
using data[0]['timestamp'], so every websocket message will be saved (e.g. 2024-01-11 21:45:1234, 2024-01-11 21:45:2561, ...)

**Now:** 
using data[0]['start'], every websocket data for the same tick will keep replacing the old one (e.g. 2024-01-11 21:45:00:2561 will replace 2024-01-11 21:45:00:1234 for the tick 2024-01-11 21:45:00)